### PR TITLE
Stop using root user for the build scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,33 +43,44 @@ RPM Based distributions
 Settings
 --------
 
- * Disable SMT
+* Disable SMT
 
 ::
 
 # sudo ppc64_cpu --smt=off
 
+* Setup environment and user
+
+::
+
+# sudo python setup_environment.py LOGIN
+
+Naturally, you need to replace LOGIN by the user name you'll use to run
+host-os-build.py, which should not run using root user, even if that user
+doesn't exists yet.
+
 Running
 -------
 
- * Build a single package
+* Build a single package
 
 ::
 
-# sudo python host-os-build.py --package libvirt
+# python host-os-build.py --package libvirt
 
- * Build all software
+* Build all software
 
 ::
 
-# sudo python host-os-build.py --verbose
+# python host-os-build.py --verbose
 
-Note the --verbose parameter to get all the log messages in the console. Insted
+Note the --verbose parameter to get all the log messages in the console. Instead
 of the standard ordinary messages. Please see --help for more options.
 
 ::
 
-# sudo python host-os-build.py --help
+# python host-os-build.py --help
+
 
 Using the RPMs
 --------------
@@ -117,7 +128,7 @@ You can use the following command to install, for instance, libseccomp's RPM:
 
 ::
 
-# sudo yum localinstall  result/libseccomp-2.3.1-0.el7.centos.1.ppc64le.rpm
+# sudo yum localinstall result/libseccomp-2.3.1-0.el7.centos.1.ppc64le.rpm
 
 Note that some of those packages are debuginfo which are recommended in order to
 provide useful information for bugs in the case of any failures.

--- a/host-os-build.py
+++ b/host-os-build.py
@@ -12,8 +12,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import os
 import logging
+import os
 import sys
 
 from lib import config
@@ -92,4 +92,9 @@ def main(args):
     return build_manager()
 
 if __name__ == '__main__':
+    if os.getuid() is 0:
+        print("Please, do not run this script as root, run "
+              "setup_environment.py script in order to properly setup user and"
+              " directory for build scripts")
+        sys.exit(3)
     sys.exit(main(sys.argv[1:]))

--- a/lib/exception.py
+++ b/lib/exception.py
@@ -60,5 +60,5 @@ class RepositoryError(BaseException):
 
 
 class SubprocessError(BaseException):
-    msg = ("%(cmd)s returned non-zero exit code: ret:%(ret)i, stdout: "
+    msg = ("%(cmd)s returned non-zero exit code: ret:%(returncode)i, stdout: "
            "%(stdout)s, stderr: %(stderr)s")

--- a/lib/exception.py
+++ b/lib/exception.py
@@ -22,6 +22,8 @@ class BaseException(Exception):
     def __init__(self, message=None, **kwargs):
         if message is None:
             message = self.msg % kwargs
+        for key, value in kwargs.items():
+            setattr(self, key, value)
         super(BaseException, self).__init__(message)
 
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -31,7 +31,7 @@ def run_command(cmd, verbose=False, **kwargs):
     output, error_output = process.communicate()
 
     if process.returncode:
-        raise exception.SubprocessError(cmd=cmd, ret=process.returncode,
+        raise exception.SubprocessError(cmd=cmd, returncode=process.returncode,
                                         stdout=output, stderr=error_output)
     if verbose:
         LOG.info("stdout: %s" % output)

--- a/setup_environment.py
+++ b/setup_environment.py
@@ -1,0 +1,30 @@
+# Copyright (C) IBM Corp. 2016.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.ofrom lib import utils
+
+import sys
+import os
+
+from tools import setup_environment
+
+ROOT = 0
+if __name__ == '__main__':
+    if os.getuid() is not ROOT:
+        print("You should run this script with root privileges.")
+        sys.exit(1)
+    if len(sys.argv) != 2:
+        print("Usage: setup_environment.py YOUR_USER_LOGIN")
+        sys.exit(1)
+
+    sys.exit(setup_environment.main(sys.argv[1]))

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (C) IBM Corp. 2016.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tools/setup_environment.py
+++ b/tools/setup_environment.py
@@ -1,0 +1,68 @@
+# Copyright (C) IBM Corp. 2016.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.ofrom lib import utils
+
+import os
+import pwd
+
+from lib import exception
+from lib import utils
+
+USER_EXISTS = 9
+DIRECTORY_EXISTS = 17
+
+
+def setup_user(user):
+    # just add the user first and if it exists proceed gracefully
+    useradd_cmd = "useradd -M %s" % (user)
+    try:
+        utils.run_command(useradd_cmd)
+    except exception.SubprocessError as e:
+        if e.returncode is USER_EXISTS:
+            pass
+        else:
+            raise
+    print("Created user %s." % user)
+    group = "mock"
+    group_cmd = "usermod -a -G %s %s" % (group, user)
+    print("Added user %s to group %s" % (user, group))
+    utils.run_command(group_cmd)
+    userdata = pwd.getpwnam(user)
+    return userdata.pw_uid, userdata.pw_gid
+
+
+def setup_directory(directory, uid, gid):
+    try:
+        os.makedirs(directory)
+    except OSError as e:
+        if e.errno is DIRECTORY_EXISTS:
+            pass
+    os.chown(directory, uid, gid)
+
+
+def setup_default_directories(log_directory, repository_directory, uid, gid):
+    setup_directory(repository_directory, uid, gid)
+    setup_directory(log_directory, uid, gid)
+
+
+def main(user):
+    # NOTE(maurosr): this is just a helper script in order to do some
+    # environment settings as it would be done if our scripts were installed
+    # through a package like rpm or deb. If the user decides to use different
+    # user or log files he needs to handle permissions by his own.
+    log_dir = "/var/log/host-os"
+    repo_dir = "/var/lib/host-os/repositories"
+
+    uid, gid = setup_user(user)
+    setup_default_directories(log_dir, repo_dir, uid, gid)


### PR DESCRIPTION
First patch of series let the **kwargs to become part of the exceptions we raise.

Second one introduces a tool setup_environment.py that creates a user in that groups OR add an existent user to it, this one though expects you to use root, for instance:

 # sudo python setup_environment.py maurosr
This creates the user maurosr, if it doesn't exist, and add it to mock group.

It also setup the **default** directories for log and repositories for that
user.
