### PR TITLE
Improve git checkout process

### DIFF
--- a/lib/repository.py
+++ b/lib/repository.py
@@ -56,22 +56,20 @@ class Repo(object):
             for remote in self.repo.remotes:
                 remote.fetch()
                 LOG.info("Fetched changes for %s" % remote.name)
-            # NOTE(maurosr): Get references and rearrange local master's HEAD
-            # we are always **assuming a fastforward**
-            remote = self.repo.lookup_reference('refs/remotes/origin/%s' % (
-                branch))
-            master = self.repo.lookup_reference('refs/heads/%s' % branch)
-            master.set_target(remote.target)
-            self.repo.head.set_target(master.target)
             LOG.info("%(package_name)s Repository updated" % locals())
 
             if commit_id:
                 LOG.info("Checking out into %s" % commit_id)
                 obj = self.repo.git_object_lookup_prefix(commit_id)
-                self.repo.checkout_tree(obj)
+                self.repo.checkout_tree(obj, strategy=pygit2.GIT_CHECKOUT_FORCE)
+                self.repo.reset(obj.oid, pygit2.GIT_RESET_HARD)
             else:
+                remote = self.repo.lookup_reference(
+                    'refs/remotes/origin/%s' % (branch))
+                # GIT_CHECKOUT_FORCE strategy cleans up the index
                 LOG.info("Checking out into %s" % branch)
-                self.repo.checkout('refs/heads/' + branch)
+                self.repo.checkout(remote, strategy=pygit2.GIT_CHECKOUT_FORCE)
+                self.repo.reset(self.repo.head.target, pygit2.GIT_RESET_HARD)
         except ValueError:
             ref = commit_id if commit_id else branch
             raise exception.RepositoryError(message="Could not find reference "


### PR DESCRIPTION
We must enforce git checkout strategy, Using GIT_CHECKOUT_FORCE strategy keeps
the tree clean after checking out into a new branch (very useful if you're
dealing with branches that change their names like happened for qemu/kernel in
our versions's tree recently).
