### PR TITLE
Escape single quotes when bumping spec version

### DIFF
--- a/upgrade_versions.py
+++ b/upgrade_versions.py
@@ -65,7 +65,8 @@ class Versions(object):
 
     def _bump_spec(self, specfile, log):
         comment = "\n".join(log)
-        cmd = "rpmdev-bumpspec -c '%s' %s" % (comment, specfile)
+        cmd = "rpmdev-bumpspec -c '%s' %s" % (comment.replace("'", "\'"),
+                                              specfile)
         utils.run_command(cmd)
 
     def _get_git_log(self, repo, since_id):


### PR DESCRIPTION
Fixes the issue when the git log string contains single quotes string 
