### PR TITLE
Remove quotes from git log messages used in spec bump

### DIFF
--- a/upgrade_versions.py
+++ b/upgrade_versions.py
@@ -71,8 +71,10 @@ class Versions(object):
     def _get_git_log(self, repo, since_id):
         log = []
         for commit in repo.walk(repo.head.target, pygit2.GIT_SORT_TOPOLOGICAL):
-            log.append("%s %s" % (commit.hex[:7],
-                                  commit.message.split('\n')[0]))
+            commit_message = commit.message.split('\n')[0]
+            commit_message = commit_message.replace("'", "")
+            commit_message = commit_message.replace("\"", "")
+            log.append("%s %s" % (commit.hex[:7], commit_message))
             if commit.hex.startswith(since_id):
                 break
 


### PR DESCRIPTION
upgrade_versions.py tool was failing when the log string to be used in change
log contains single quotes unmatched, so let's remove them and to avoid such
caveats.
