### PR TITLE
README: Fix typo in packages list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ $ sudo yum localinstall epel-release-7-5.noarch.rpm # Note the version may chang
 
 ::
 
-$ sudo yum install -y bzip2 git mock pyton-pygit2 PyYAML svn wget
+$ sudo yum install -y bzip2 git mock python-pygit2 PyYAML svn wget
 
 Settings
 --------


### PR DESCRIPTION
Commit 11a9c8e "README: Sort packages lists" introduced a typo in the
python-pygit2 package name.
