### PR TITLE
Do not remove build dependencies

### DIFF
--- a/lib/distro.py
+++ b/lib/distro.py
@@ -59,5 +59,3 @@ class LinuxDistribution(object):
 
     def clean(self, packages):
         self.package_builder.clean()
-        for package in packages:
-            package.clean_build_dependencies()

--- a/lib/package.py
+++ b/lib/package.py
@@ -181,16 +181,3 @@ class Package(object):
             filename = os.path.join(self.build_files, url.split('/')[-1])
             with open(filename, "wb") as file_data:
                 file_data.write(data)
-
-    def clean_build_dependencies(self):
-        """
-        This is a very simple method were the package cleans up its own RPMs
-        if it fits on BUILD_DEPENDENCIES category.
-        There is no need, now, to go recursively cause this method will be
-        called for all packages built.
-        Straightforward right now where a build dep is never a package itself.
-        """
-        print("%s: Removing build dependencies" % self.name)
-        if self.category is BUILD_DEPENDENCIES:
-            for f in self.result_packages:
-                os.remove(f)


### PR DESCRIPTION
Do not remove build dependencies and let them in the `result` directory.
- 475f01e Remove unused clean_build_dependencies()
- cd3a3b8 Do not call clean_build_dependencies()
