### PR TITLE
Enable tmpfs plugin in mock

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,3 +9,8 @@ default:
  arch_and_endianness: 'ppc64le'
  release_notes_repo_url: "https://github.com/open-power-host-os/open-power-host-os.github.io.git"
  release_notes_repo_branch: "master"
+ mock_args:
+   "--enable-plugin=tmpfs
+   --plugin-option=tmpfs:keep_mounted=True
+   --plugin-option=tmpfs:max_fs_size=50g
+   --plugin-option=tmpfs:required_ram_mb=4096"

--- a/lib/config.py
+++ b/lib/config.py
@@ -118,6 +118,9 @@ class ConfigParser(object):
         self.parser.add_argument('--keep-builddir',
                                  help='Keep build directory and its logs and '
                                  'artifacts.', action='store_true')
+        self.parser.add_argument('--mock-args',
+                                 help='Arguments passed to mock command',
+                                 default='')
         self.parser.add_argument('--build-versions-repository-url',
                                  help='Build versions repository URL')
         self.parser.add_argument('--build-version',

--- a/lib/mockbuilder.py
+++ b/lib/mockbuilder.py
@@ -33,6 +33,7 @@ class Mock(build_system.PackageBuilder):
     def __init__(self, config):
         super(Mock, self).__init__()
         self.mock_config = config
+        self.mock_args = CONF.get('default').get('mock_args')
         self.result_dir = CONF.get('default').get('result_dir')
         self.build_dir = None
         self.archive = None
@@ -43,7 +44,8 @@ class Mock(build_system.PackageBuilder):
         packages. This setup is common for all packages that are built
         and needs to be done only once.
         """
-        cmd = "%s --init -r %s " % (MOCK_BIN, self.mock_config)
+        cmd = "%s --init -r %s %s " % (MOCK_BIN, self.mock_config,
+                                       self.mock_args)
         utils.run_command(cmd)
 
     def build(self, package):
@@ -51,9 +53,9 @@ class Mock(build_system.PackageBuilder):
         self._prepare(package)
         self._build_srpm(package)
         self._install_external_dependencies(package)
-        cmd = "%s -r %s --rebuild %s --no-clean --resultdir=%s" % (
-            MOCK_BIN, self.mock_config, self.build_dir + "/*.rpm",
-            self.build_dir)
+        cmd = "%s -r %s %s --rebuild %s --no-clean --resultdir=%s" % (
+            MOCK_BIN, self.mock_config, self.mock_args,
+            self.build_dir + "/*.rpm", self.build_dir)
 
         if package.rpmmacro:
             cmd = cmd + " --macro-file=%s" % package.rpmmacro
@@ -78,9 +80,10 @@ class Mock(build_system.PackageBuilder):
 
     def _build_srpm(self, package):
         LOG.info("%s: Building SRPM" % package.name)
-        cmd = ("%s -r %s --buildsrpm --no-clean --spec %s --source %s "
+        cmd = ("%s -r %s %s --buildsrpm --no-clean --spec %s --source %s "
                "--resultdir=%s" % (MOCK_BIN,
                                    self.mock_config,
+                                   self.mock_args,
                                    package.spec_file.path,
                                    self.archive,
                                    self.build_dir))
@@ -103,7 +106,7 @@ class Mock(build_system.PackageBuilder):
             self.archive = package._download_source(self.build_dir)
 
     def _copy_files_to_chroot(self, package):
-        cmd = "%s -r %s " % (MOCK_BIN, self.mock_config)
+        cmd = "%s -r %s %s " % (MOCK_BIN, self.mock_config, self.mock_args)
 
         files = []
         for f in os.listdir(package.build_files):
@@ -117,7 +120,7 @@ class Mock(build_system.PackageBuilder):
         utils.run_command("%s --clean" % MOCK_BIN)
 
     def _install_external_dependencies(self, package):
-        cmd = "%s -r %s " % (MOCK_BIN, self.mock_config)
+        cmd = "%s -r %s %s " % (MOCK_BIN, self.mock_config, self.mock_args)
         if package.build_dependencies or package.dependencies:
             install = " --install"
             for dep in package.build_dependencies:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 nose==1.3.7
 nose-parameterized==0.5.0
+PyYAML==3.12

--- a/tests/unit/config_tests.py
+++ b/tests/unit/config_tests.py
@@ -20,6 +20,7 @@ class TestConfigParser(unittest.TestCase):
         ('--keep-builddir', 'keep_builddir', True),
         ('--build-versions-repository-url=foo', 'build_versions_repository_url', 'foo'),
         ('--build-version=foo', 'build_version', 'foo'),
+        ('--mock-args=foo', 'mock_args', 'foo'),
     ])
     def test_parse_arguments_list_WithLongArgument_ShouldParseArgumentValue(self, argument, key, expected):
         cfg = ConfigParser()
@@ -39,6 +40,7 @@ class TestConfigParser(unittest.TestCase):
         ('keep_builddir', False),
         ('build_versions_repository_url', None),
         ('build_version', None),
+        ('mock_args', ''),
     ])
     def test_parse_arguments_list_WithoutArgument_ShouldUseDefaultValue(self, key, expected):
         cfg = ConfigParser()


### PR DESCRIPTION
Add `--mock-args` switch to `host-os-build.py` script as well as its test cases.  And fix a minor issue with a missing module in `requirements-dev.txt`.

* 41f57ae Add test cases for --mock-args parameter
* a3643d8 Add PyYAML in requirements-dev.txt
* 04f23f1 Pass mock_args to mock command
* 7159e91 Add mock_args option in config.yaml