### PR TITLE
Support multiple success return codes in run_command

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -31,6 +31,7 @@ def set_http_proxy_env(proxy):
 def run_command(cmd, **kwargs):
     LOG.debug("Command: %s" % cmd)
     shell = kwargs.pop('shell', True)
+    success_return_codes = kwargs.pop('success_return_codes', [0])
 
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE, shell=shell, **kwargs)
@@ -39,7 +40,7 @@ def run_command(cmd, **kwargs):
     LOG.debug("stdout: %s" % output)
     LOG.debug("stderr: %s" % error_output)
 
-    if process.returncode:
+    if process.returncode not in success_return_codes:
         raise exception.SubprocessError(cmd=cmd, returncode=process.returncode,
                                         stdout=output, stderr=error_output)
 

--- a/tools/setup_environment.py
+++ b/tools/setup_environment.py
@@ -16,7 +16,6 @@
 import os
 import pwd
 
-from lib import exception
 from lib import utils
 
 USER_EXISTS = 9
@@ -26,14 +25,7 @@ DIRECTORY_EXISTS = 17
 def setup_user(user):
     # just add the user first and if it exists proceed gracefully
     useradd_cmd = "useradd -M %s" % (user)
-    try:
-        utils.run_command(useradd_cmd)
-    except exception.SubprocessError as e:
-        # pylint: disable=no-member
-        if e.returncode is USER_EXISTS:
-            pass
-        else:
-            raise
+    utils.run_command(useradd_cmd, success_return_codes=[0, USER_EXISTS])
     print("Created user %s." % user)
     group = "mock"
     group_cmd = "usermod -a -G %s %s" % (group, user)


### PR DESCRIPTION
This new parameter does not affect existing run_command() calls, as it uses [0] as default value.