### PR TITLE
Remove libguestfs from the list of packages added to iso

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,6 @@ iso:
             - "iprutils"
             - "kernel"
             - "kimchi"
-            - "libguestfs"
             - "libseccomp"
             - "libvirt"
             - "libvirt-daemon-kvm"


### PR DESCRIPTION
We are no longer building this package, so there is no need to mention
it explicitly. It will be taken from the CentOS extras repository.