### PR TITLE
Fix cleaning of mock chroot

### DIFF
--- a/lib/mockbuilder.py
+++ b/lib/mockbuilder.py
@@ -123,7 +123,8 @@ class Mock(build_system.PackageBuilder):
             shutil.copy(file_path, self.archive)
 
     def clean(self):
-        utils.run_command("%s --clean" % MOCK_BIN)
+        utils.run_command("%s --clean -r %s %s" % (MOCK_BIN, self.mock_config,
+                                                   self.mock_args))
 
     def _install_external_dependencies(self, package):
         cmd = "%s -r %s %s " % (MOCK_BIN, self.mock_config, self.mock_args)


### PR DESCRIPTION
When using the tmpfs plugin, mock creates an extra mount point:

mock_chroot_tmpfs on /var/lib/mock/epel-7-ppc64le/root type tmpfs

This mount point is only unmounted if --clean is run with the tmpfs
plugin enabled.