### PR TITLE
Fix 'files' attribute loading from package metadata (yaml) file

### DIFF
--- a/lib/rpm_package.py
+++ b/lib/rpm_package.py
@@ -151,7 +151,7 @@ class RPM_Package(Package):
 
             # load distro files
             files = self.package_data.get('files', {}).get(
-                distro_attrib_name, {}).get(self.distro.version, {})
+                distro_attrib_name, {}).get(self.distro.version, {}) or {}
 
             default_build_files_dir_rel_path = os.path.join(
                 self.distro.lsb_name, self.distro.version, "SOURCES")


### PR DESCRIPTION
Regression introduced in commit a55b46d7df91d62bc0a239b28ec547b258e783b2.