### PR TITLE
Change runtime dependencies attrib name and behavior in build

### DIFF
--- a/lib/mockbuilder.py
+++ b/lib/mockbuilder.py
@@ -125,12 +125,10 @@ class Mock(build_system.PackageBuilder):
         utils.run_command(self.common_mock_args + " --clean")
 
     def _install_external_dependencies(self, package):
-        if package.build_dependencies or package.install_dependencies:
+        if package.build_dependencies:
             cmd = self.common_mock_args
             install = " --install"
             for dep in package.build_dependencies:
-                install = " ".join([install, " ".join(dep.result_packages)])
-            for dep in package.install_dependencies:
                 install = " ".join([install, " ".join(dep.result_packages)])
 
             cmd = cmd + install

--- a/lib/mockbuilder.py
+++ b/lib/mockbuilder.py
@@ -125,12 +125,12 @@ class Mock(build_system.PackageBuilder):
         utils.run_command(self.common_mock_args + " --clean")
 
     def _install_external_dependencies(self, package):
-        if package.build_dependencies or package.dependencies:
+        if package.build_dependencies or package.install_dependencies:
             cmd = self.common_mock_args
             install = " --install"
             for dep in package.build_dependencies:
                 install = " ".join([install, " ".join(dep.result_packages)])
-            for dep in package.dependencies:
+            for dep in package.install_dependencies:
                 install = " ".join([install, " ".join(dep.result_packages)])
 
             cmd = cmd + install

--- a/lib/package.py
+++ b/lib/package.py
@@ -54,7 +54,7 @@ class Package(object):
         self.name = name
         self.clone_url = None
         self.download_source = None
-        self.dependencies = []
+        self.install_dependencies = []
         self.build_dependencies = []
         self.result_packages = []
         self.sources = []
@@ -116,7 +116,7 @@ class Package(object):
 
         self._download_build_files()
         if recurse:
-            for dep in (self.dependencies + self.build_dependencies):
+            for dep in (self.install_dependencies + self.build_dependencies):
                 dep.download_files()
 
     def _download_source_code(self):

--- a/lib/rpm_package.py
+++ b/lib/rpm_package.py
@@ -161,9 +161,15 @@ class RPM_Package(Package):
             self.download_build_files = files.get('download_build_files', [])
 
             # list of dependencies
+            for dep_name in files.get('install_dependencies', []):
+                dep = RPM_Package.get_instance(dep_name, self.distro)
+                self.install_dependencies.append(dep)
+
+            # keeps backward compatibility with old yaml files which have 'dependencies'
+            # instead of 'install_dependencies'
             for dep_name in files.get('dependencies', []):
                 dep = RPM_Package.get_instance(dep_name, self.distro)
-                self.dependencies.append(dep)
+                self.install_dependencies.append(dep)
 
             for dep_name in files.get('build_dependencies', []):
                 dep = RPM_Package.get_instance(dep_name, self.distro)

--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -47,6 +47,9 @@ class Scheduler(object):
         else:
             if p not in visited:
                 visited.append(p)
+                # runtime dependencies do not need to be built before the package,
+                # they can be built anytime. We randomly chose to prioritize building
+                # installation dependencies before the package.
                 if p.install_dependencies:
                     order.extend(self._dfs(p.install_dependencies, visited))
                 if p.build_dependencies:

--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -47,8 +47,8 @@ class Scheduler(object):
         else:
             if p not in visited:
                 visited.append(p)
-                if p.dependencies:
-                    order.extend(self._dfs(p.dependencies, visited))
+                if p.install_dependencies:
+                    order.extend(self._dfs(p.install_dependencies, visited))
                 if p.build_dependencies:
                     order.extend(self._dfs(p.build_dependencies, visited))
                 order.append(p)


### PR DESCRIPTION
- Rename dependencies attrib in yaml to runtime_dependencies
- Stop installing runtime dependencies in chroot used to build package
- Stop building runtime dependencies before dependent package