### PR TITLE
Remove documentation about SMT from README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,12 +182,6 @@ failures.
 Also no version is informed on the list above to make it valid even
 for future versions with minor version changes.
 
-When using virtualization packages, SMT needs to be disabled:
-
-::
-
-$ sudo ppc64_cpu --smt=off
-
 
 Validating
 ----------


### PR DESCRIPTION
Depends on open-power-host-os/versions#142

We are going to deliver this modification via a systemd unit installed along with qemu package so the doc about turning SMT off needs to be removed.