### PR TITLE
Add extras repository in ISO list

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -72,4 +72,5 @@ iso:
     distro_repo_url:
         base: "http://mirror.centos.org/altarch/7/os/ppc64le/"
         updates: "http://mirror.centos.org/altarch/7/updates/ppc64le/"
+        extras: "http://mirror.centos.org/altarch/7/extras/ppc64le/"
         epel: "http://download.fedoraproject.org/pub/epel/7/ppc64le/"


### PR DESCRIPTION
docker and kimchi added dependencies available on extras repository,
hence this repo must be added in the ISO spin process