### PR TITLE
Move development documentation to other files

### DIFF
--- a/BUILD_OLD_VERSIONS.md
+++ b/BUILD_OLD_VERSIONS.md
@@ -1,0 +1,40 @@
+# Build old versions
+
+OpenPOWER Host OS 1.0 and 1.5 used an older CentOS (7.2) as base version.
+To build one of them, do the following changes in this git repository
+before building:
+
+Update yum repository to CentOS 7.2:
+
+```
+$ sed -i 's|http://mirror.centos.org/altarch/|http://vault.centos.org/altarch/7.2.1511/|' mock_configs/CentOS/7/CentOS-7-ppc64le.cfg
+```
+
+Update distro version to 7.2:
+
+```
+$ sed -i "s|distro_version:.*|distro_version: \"7.2\"|" config.yaml
+$ sed -i -E "s|  '7': (\"\./mock_configs.*)|  '7.2': \1|" config.yaml
+```
+
+Update build version to v1.5.0 or v1.0.0:
+
+```
+$ sed -i "s|build_version:.*|build_version: \"v1.5.0\"|" config.yaml  # use v1.5.0 or v1.0.0
+```
+
+Install rpm packages which were used in older build code, but are not anymore:
+
+```
+$ yum install -y bzip2 wget
+```
+
+Clean yum repositories cache in mock:
+
+```
+$ mock --scrub all
+```
+
+These steps are documented in
+https://github.com/open-power-host-os/infrastructure/tree/master/jenkins_jobs/build_old_host_os_versions/script.sh .
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,54 @@ Also, please, follow the code style proposed by [PEP8](https://www.python.org/de
 
 For details on adding new packages to the project, refer to the versions repository documentation at https://github.com/open-power-host-os/versions/blob/master/CONTRIBUTING.md.
 
+## Validating
+
+There is a whole repository dedicated to testing available at
+https://github.com/open-power-host-os/tests
+
+In order to run the build scripts unit tests or code linter, you will need to
+install our development dependencies.
+
+You can do this by issuing the command below
+
+```
+$ sudo pip install -r requirements-dev.txt
+```
+
+### Running code linter
+
+From the root of the `builds` project directory, use the commands below to run
+the code linter (Pylint):
+
+```
+$ PYTHON_FILES=$(find . -name "*.py")
+$ pylint $PYTHON_FILES
+```
+
+### Running unit tests
+
+From the root of the `builds` project directory, use the commands below to run
+the unit tests:
+
+```
+$ export PYTHONPATH=$(pwd):$PYTHONPATH
+$ nosetests tests/unit
+```
+
+## ISO image
+
+* Build Host OS ISO image
+
+```
+$ ./host_os.py --verbose build-iso
+```
+
+Please see `--help` for more options.
+
+```
+$ ./host_os.py build-iso --help
+```
+
 ## Issues
 
 Feel free to open an issue at any moment [here](https://github.com/open-power-host-os/builds/issues).

--- a/README.md
+++ b/README.md
@@ -78,43 +78,7 @@ $ ./host_os.py build-packages --help
 
 * Build old versions
 
-OpenPOWER Host OS 1.0 and 1.5 used an older CentOS (7.2) as base version.
-To build one of them, do the following changes in this git repository
-before building:
-
-Update yum repository to CentOS 7.2:
-
-```
-$ sed -i 's|http://mirror.centos.org/altarch/|http://vault.centos.org/altarch/7.2.1511/|' mock_configs/CentOS/7/CentOS-7-ppc64le.cfg
-```
-
-Update distro version to 7.2:
-
-```
-$ sed -i "s|distro_version:.*|distro_version: \"7.2\"|" config.yaml
-$ sed -i -E "s|  '7': (\"\./mock_configs.*)|  '7.2': \1|" config.yaml
-```
-
-Update build version to v1.5.0 or v1.0.0:
-
-```
-$ sed -i "s|build_version:.*|build_version: \"v1.5.0\"|" config.yaml  # use v1.5.0 or v1.0.0
-```
-
-Install rpm packages which were used in older build code, but are not anymore:
-
-```
-$ yum install -y bzip2 wget
-```
-
-Clean yum repositories cache in mock:
-
-```
-$ mock --scrub all
-```
-
-These steps are documented in
-https://github.com/open-power-host-os/infrastructure/tree/master/jenkins_jobs/build_old_host_os_versions/script.sh .
+For details on building OpenPOWER Host OS old versions, refer to the documentation at https://github.com/open-power-host-os/builds/blob/master/BUILD_OLD_VERSIONS.md.
 
 * Build custom software
 

--- a/README.md
+++ b/README.md
@@ -160,54 +160,6 @@ When using virtualization packages, SMT needs to be disabled:
 $ sudo ppc64_cpu --smt=off
 ```
 
-## Validating
-
-There is a whole repository dedicated to testing available at
-https://github.com/open-power-host-os/tests
-
-In order to run the build scripts unit tests or code linter, you will need to
-install our development dependencies.
-
-You can do this by issuing the command below
-
-```
-$ sudo pip install -r requirements-dev.txt
-```
-
-### Running code linter
-
-From the root of the `builds` project directory, use the commands below to run
-the code linter (Pylint):
-
-```
-$ PYTHON_FILES=$(find . -name "*.py")
-$ pylint $PYTHON_FILES
-```
-
-### Running unit tests
-
-From the root of the `builds` project directory, use the commands below to run
-the unit tests:
-
-```
-$ export PYTHONPATH=$(pwd):$PYTHONPATH
-$ nosetests tests/unit
-```
-
-## ISO image
-
-* Build Host OS ISO image
-
-```
-$ ./host_os.py --verbose build-iso
-```
-
-Please see `--help` for more options.
-
-```
-$ ./host_os.py build-iso --help
-```
-
 ## Contact us
 
 If you are interested, you might always stop by in `#hostos` on irc.freenode.net.


### PR DESCRIPTION
We have some development documentation that is being kept in README.md. That could me moved to CONTRIBUTING.md so that we keep user and devel docs separated.
Information related to build old versions was moved to a new file BUILD_OLD_VERSIONS.md.