### PR TITLE
Add createrepo to RPM requirements

### DIFF
--- a/rpm_requirements.txt
+++ b/rpm_requirements.txt
@@ -1,5 +1,6 @@
 GitPython
 PyYAML
+createrepo
 git
 lzop
 mock


### PR DESCRIPTION
createrepo execution was added to create yum repositories, but the
corresponding rpm package was not added to rpm_requirements.txt.