### PR TITLE
Add support for pungi arguments

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,7 @@ common:
  distro_version: '7'
  architecture: 'ppc64le'
  mock_binary: "/usr/bin/mock"
+ pungi_binary: "/usr/bin/pungi"
  commit_updates: True
  push_updates: True
  updater_name:
@@ -46,6 +47,7 @@ build_iso:
       --plugin-option=tmpfs:max_fs_size=32g
       --plugin-option=tmpfs:required_ram_mb=39800
       --verbose"
+    pungi_args: "--isfinal --nosource --nodebuginfo"
     packages_dir: "result/packages/latest"
     automated_install_file: "host-os.ks"
     installable_environments:

--- a/lib/config.py
+++ b/lib/config.py
@@ -72,6 +72,10 @@ MOCK_ARGS = {
     ('--mock-args',):
         dict(help='Arguments passed to mock command', default=''),
 }
+PUNGI_ARGS = {
+    ('--pungi-binary',): dict(help='Pungi binary path'),
+    ('--pungi-args',): dict(help='Arguments passed to pungi command'),
+}
 RELEASE_NOTES_ARGS = {
     ('--release-notes-repo-url',):
         dict(help='Release notes repository URL'),
@@ -149,7 +153,7 @@ SUBCOMMANDS = [
     ('update-versions-readme', 'Update the supported software versions table',
         [PUSH_REPO_ARGS, DISTRO_ARGS, BUILD_REPO_ARGS]),
     ('build-iso', 'Build ISO image',
-        [ISO_ARGS, MOCK_ARGS, BUILD_ARGS]),
+        [ISO_ARGS, MOCK_ARGS, PUNGI_ARGS, BUILD_ARGS]),
 ]
 
 

--- a/lib/iso_builder.py
+++ b/lib/iso_builder.py
@@ -42,6 +42,8 @@ class MockPungiIsoBuilder(object):
         (_, _, self.arch) = distro_utils.detect_distribution()
         self.mock_binary = self.common_config.get('mock_binary')
         self.mock_args = self.config.get('mock_args') or ""
+        self.pungi_binary = self.common_config.get('pungi_binary') or "pungi"
+        self.pungi_args = self.config.get('pungi_args') or ""
 
     def _run_mock_command(self, cmd):
         distro = distro_utils.get_distro(
@@ -141,8 +143,9 @@ class MockPungiIsoBuilder(object):
 
     def _build(self):
         LOG.info("Building ISO")
-        build_cmd = ("pungi -c %s --nosource --nodebuginfo --name %s --ver %s" %
-                    (self.config.get('automated_install_file'),
+        build_cmd = ("%s %s -c %s --name %s --ver %s" %
+                    (self.pungi_binary, self.pungi_args,
+                     self.config.get('automated_install_file'),
                      self.distro, self.version))
         self._run_mock_command("--shell '%s'" % build_cmd)
 


### PR DESCRIPTION
This series of patches add support to specify pungi arguments during the build of the iso image.  It also handles invalid git repositories properly, in case a non-git repository exists at the repository path.