### PR TITLE
Fixed link to 'Building an ISO' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To install them, follow the instructions [here](INSTALLING_PACKAGES.md).
 ## Building an ISO
 
 To build an ISO with the built packages, follow those
-[instructions](BUILDING_AN_ISO).
+[instructions](BUILDING_AN_ISO.md).
 
 
 ## Contact us


### PR DESCRIPTION
Added an '.md' at the end of BUILDING_AN_ISO at line 106.