### PR TITLE
Log empty packages

### DIFF
--- a/lib/exception.py
+++ b/lib/exception.py
@@ -70,6 +70,11 @@ class PackageDescriptorError(PackageError):
     error_code = 18
 
 
+class PackageDirectoryIsEmpty(PackageError):
+    DEFAULT_MESSAGE = "No packages to build. Packages directory is empty."
+    error_code =  19
+
+
 class RepositoryError(BaseException):
     DEFAULT_MESSAGE = (
         "Failed to setup %(repo_name)s's repository at %(repo_path)s.")

--- a/lib/packages_manager.py
+++ b/lib/packages_manager.py
@@ -85,4 +85,7 @@ def discover_packages():
         LOG.error("No packages found in versions repository directory")
         raise
 
+    if not package_list:
+    	raise exception.PackageDirectoryIsEmpty()
+
     return package_list


### PR DESCRIPTION
Print an error when there are no packages to build. 