### PR TITLE
Fix validate scripts execution from repository root directory

### DIFF
--- a/scripts/validate_rpm_specs.py
+++ b/scripts/validate_rpm_specs.py
@@ -15,9 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import os
 import sys
 
-sys.path.insert(0, '..')
+repo_root_dir = os.path.realpath(os.path.join(
+    os.path.dirname(__file__), os.pardir))
+sys.path.insert(0, repo_root_dir)
 
 from lib import exception
 from lib.utils import is_package_installed

--- a/scripts/validate_yamls.py
+++ b/scripts/validate_yamls.py
@@ -15,9 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import os
 import sys
 
-sys.path.insert(0, '..')
+repo_root_dir = os.path.realpath(os.path.join(
+    os.path.dirname(__file__), os.pardir))
+sys.path.insert(0, repo_root_dir)
 
 from lib import exception
 from lib.utils import is_package_installed


### PR DESCRIPTION
By inserting ".." into the path, we allowed the execution only from a
subdirectory (e.g. scripts/). Since the .yamllint and .rpmlint files are
in the root directory, it is preferred to execute those scripts from
there.