### PR TITLE
Update ISO checksum filename

### DIFF
--- a/lib/iso_builder.py
+++ b/lib/iso_builder.py
@@ -156,8 +156,7 @@ class MockPungiIsoBuilder(object):
         utils.force_symlink(self.timestamp, latest_dir)
 
         iso_file = "%s-DVD-%s-%s.iso" % (self.distro, self.arch, self.version)
-        checksum_file = ("%s-%s-%s-CHECKSUM" %
-                         (self.distro, self.version, self.arch))
+        checksum_file = "%s.sha256" % iso_file
         iso_dir = "/%s/%s/iso" % (self.version, self.arch)
         iso_path = os.path.join(iso_dir, iso_file)
         checksum_path = os.path.join(iso_dir, checksum_file)


### PR DESCRIPTION
Depends on https://github.com/open-power-host-os/infrastructure/pull/70

Currently, the ISO filename and its checksum file have different formats. An
example follows:

OpenPOWER-Host_OS-170503-ppc64le-CHECKSUM
OpenPOWER-Host_OS-DVD-ppc64le-170503.iso

Appending ".sha256" to the ISO filename to constitute the checksum file makes
filenames more consistent. An example follows:

OpenPOWER-Host_OS-DVD-ppc64le-170503.iso
OpenPOWER-Host_OS-DVD-ppc64le-170503.iso.sha256

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>