### PR TITLE
Fix typo in scheduler.py

### DIFF
--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -71,7 +71,7 @@ class Scheduler(object):
         """
 
         self.packages = packages
-        LOG.info("Scheduling packages and their dependecies: %s" % packages)
+        LOG.info("Scheduling packages and their dependencies: %s" % packages)
         ordered_packages = self._dfs(packages, [])
         LOG.debug("Scheduled order: %s" % ordered_packages)
         return tuple(ordered_packages)


### PR DESCRIPTION
Replaced _"dependecies"_ by _"dependencies"_  in `scheduler.py`. 
Replaced _"withouth"_ by _"without"_ in `/builds/workspace/repositories/gcc/gcc/sched-deps` (untracked).

Some other untracked files were also affected by the replace commands. 