### PR TITLE
Revert "Update ISO checksum filename"

### DIFF
--- a/lib/iso_builder.py
+++ b/lib/iso_builder.py
@@ -156,7 +156,8 @@ class MockPungiIsoBuilder(object):
         utils.force_symlink(self.timestamp, latest_dir)
 
         iso_file = "%s-DVD-%s-%s.iso" % (self.distro, self.arch, self.version)
-        checksum_file = "%s.sha256" % iso_file
+        checksum_file = ("%s-%s-%s-CHECKSUM" %
+                         (self.distro, self.version, self.arch))
         iso_dir = "/%s/%s/iso" % (self.version, self.arch)
         iso_path = os.path.join(iso_dir, iso_file)
         checksum_path = os.path.join(iso_dir, checksum_file)


### PR DESCRIPTION
Revert "Update ISO checksum filename"

This reverts commit 6c5e63750a91118db33ccff03408dcd9ba938023.

The above patch broke build-iso subcommand because the checksum file was still
being created as `*-CHECKSUM` and the wrong path was passed to mock --copyout
parameter.

Renaming the checksum file will likely happen in _save() function after files
are copied out from mock.

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>