### PR TITLE
Add iso version to build-iso subcommand

### DIFF
--- a/config/host_os.yaml
+++ b/config/host_os.yaml
@@ -18,7 +18,7 @@ build-iso:
     - open-power-host-os-virt
     OpenPOWER Host OS virtualization management:
     - open-power-host-os-virt-management
-  iso_name: OpenPOWER-Host_OS
+  iso_name: Host_OS
   iso_repo_packages: []
   iso_repo_packages_groups:
   - OpenPOWER Host OS all

--- a/config/host_os.yaml
+++ b/config/host_os.yaml
@@ -27,6 +27,7 @@ build-iso:
   - OpenPOWER Host OS virtualization
   - OpenPOWER Host OS virtualization management
   - OpenPOWER Host OS RAS
+  iso_version: ''
   mock_args: --enable-plugin=tmpfs --plugin-option=tmpfs:keep_mounted=True --plugin-option=tmpfs:max_fs_size=32g
     --plugin-option=tmpfs:required_ram_mb=39800 --verbose
   mock_binary: /usr/bin/mock

--- a/config/metadata.yaml
+++ b/config/metadata.yaml
@@ -71,6 +71,10 @@ options:
     - OpenPOWER Host OS virtualization
     - OpenPOWER Host OS virtualization management
     - OpenPOWER Host OS RAS
+  iso_version:
+    help: ISO version
+    # If empty, current date is used
+    default: ''
   keep_build_dir:
     help: Keep build directory and its logs and artifacts
     default: False
@@ -220,6 +224,7 @@ commands:
     - iso_name
     - iso_repo_packages
     - iso_repo_packages_groups
+    - iso_version
     - mock_args
     - mock_binary
     - mock_iso_repo_dir

--- a/config/metadata.yaml
+++ b/config/metadata.yaml
@@ -54,7 +54,7 @@ options:
       - open-power-host-os-ras
   iso_name:
     help: ISO name
-    default: OpenPOWER-Host_OS
+    default: Host_OS
   iso_repo_packages:
     help: Packages that will be available in the ISO yum
       repository, in addition to the ones required by a minimal

--- a/lib/iso_builder.py
+++ b/lib/iso_builder.py
@@ -37,7 +37,8 @@ class MockPungiIsoBuilder(object):
         self.result_dir = os.path.join(self.config.get('result_dir'),
             'iso', self.timestamp)
         self.distro = self.config.get("iso_name")
-        self.version = datetime.date.today().strftime("%y%m%d")
+        self.version = (self.config.get("iso_version")
+                            or datetime.date.today().strftime("%y%m%d"))
         (_, _, self.arch) = distro_utils.detect_distribution()
         self.mock_binary = self.config.get('mock_binary')
         self.mock_args = self.config.get('mock_args') or ""


### PR DESCRIPTION
This adds --iso-version param to build-iso subcommand of host_os.py, allowing an
iso version to be specified to the final iso name; and shortens iso name to comply
with the 32-characters restriction in the volume id.