### PR TITLE
Add --uniqueext to mock command in MockPungiIsoBuilder

### DIFF
--- a/lib/build_manager.py
+++ b/lib/build_manager.py
@@ -18,7 +18,7 @@ import os
 
 from lib import config
 from lib import exception
-from lib import mockbuilder
+from lib.mock_package_builder import MockPackageBuilder
 from lib.packages_manager import PackagesManager
 from lib.rpm_package import RPM_Package
 import lib.centos
@@ -53,7 +53,7 @@ class BuildManager(object):
             if not os.path.isfile(mock_config_file_path):
                 raise exception.BaseException(
                     "Mock config file not found at %s" % mock_config_file_path)
-            package_builder = mockbuilder.Mock(mock_config_file_path)
+            package_builder = MockPackageBuilder(mock_config_file_path)
         else:
             raise exception.DistributionError()
         # create packages

--- a/lib/iso_builder.py
+++ b/lib/iso_builder.py
@@ -62,7 +62,8 @@ class MockPungiIsoBuilder(object):
         extra_args = self.config.get('mock_args') or ""
 
         self.common_mock_args = [
-            binary_file, "-r", mock_config_file_path, extra_args]
+            binary_file, "-r", mock_config_file_path, extra_args,
+            "--uniqueext", self.timestamp]
 
     def _run_mock_command(self, cmd):
         cmd = " ".join(self.common_mock_args + [cmd])

--- a/lib/iso_builder.py
+++ b/lib/iso_builder.py
@@ -22,6 +22,7 @@ from lib import utils
 from lib import distro_utils
 from lib import packages_groups_xml_creator
 from lib.constants import LATEST_SYMLINK_NAME
+from lib.mock import Mock
 
 LOG = logging.getLogger(__name__)
 ISO_REPO_MINIMAL_PACKAGES_GROUPS = ["core", "anaconda-tools"]
@@ -43,9 +44,12 @@ class MockPungiIsoBuilder(object):
         self.pungi_binary = self.config.get('pungi_binary') or "pungi"
         self.pungi_args = self.config.get('pungi_args') or ""
 
-        self._init_common_mock_args()
+        self._init_mock()
 
-    def _init_common_mock_args(self):
+    def _init_mock(self):
+        """
+        Initialize Mock instance with common mock arguments.
+        """
         distro = distro_utils.get_distro(
             self.config.get('distro_name'),
             self.config.get('distro_version'),
@@ -58,20 +62,8 @@ class MockPungiIsoBuilder(object):
         if not os.path.isfile(mock_config_file_path):
             raise exception.BaseException(
                 "Mock config file not found at %s" % mock_config_file_path)
-        binary_file = self.config.get('mock_binary')
-        extra_args = self.config.get('mock_args') or ""
 
-        self.common_mock_args = [
-            binary_file, "-r", mock_config_file_path, extra_args,
-            "--uniqueext", self.timestamp]
-
-    def _run_mock_command(self, cmd):
-        cmd = " ".join(self.common_mock_args + [cmd])
-        try:
-            utils.run_command(cmd)
-        except exception.SubprocessError:
-            LOG.error("Failed to build ISO")
-            raise
+        self.mock = Mock(mock_config_file_path, self.timestamp)
 
     def build(self):
         LOG.info("Starting ISO build process")
@@ -81,11 +73,11 @@ class MockPungiIsoBuilder(object):
 
     def _setup(self):
         LOG.info("Initializing a chroot")
-        self._run_mock_command("--init")
+        self.mock.run_command("--init")
 
         package_list = ["createrepo", "pungi"]
         LOG.info("Installing %s inside the chroot" % " ".join(package_list))
-        self._run_mock_command("--install %s" % " ".join(package_list))
+        self.mock.run_command("--install %s" % " ".join(package_list))
 
         self._create_iso_repo()
 
@@ -96,13 +88,13 @@ class MockPungiIsoBuilder(object):
 
         LOG.debug("Creating ISO yum repository directory")
         mock_iso_repo_dir = self.config.get('mock_iso_repo_dir')
-        self._run_mock_command("--shell 'mkdir -p %s'" % mock_iso_repo_dir)
+        self.mock.run_command("--shell 'mkdir -p %s'" % mock_iso_repo_dir)
 
         LOG.debug("Copying rpm packages to ISO yum repo directory")
         packages_dir = self.config.get('packages_dir')
         rpm_files = utils.recursive_glob(packages_dir, "*.rpm")
-        self._run_mock_command("--copyin %s %s" %
-                               (" ".join(rpm_files), mock_iso_repo_dir))
+        self.mock.run_command("--copyin %s %s" %
+                              (" ".join(rpm_files), mock_iso_repo_dir))
 
         LOG.debug("Creating package groups metadata file (comps.xml)")
         comps_xml_str = packages_groups_xml_creator.create_comps_xml(
@@ -117,13 +109,13 @@ class MockPungiIsoBuilder(object):
             raise
 
         comps_xml_chroot_path = os.path.join("/", comps_xml_file)
-        self._run_mock_command("--copyin %s %s" %
-                               (comps_xml_path, comps_xml_chroot_path))
+        self.mock.run_command("--copyin %s %s" %
+                              (comps_xml_path, comps_xml_chroot_path))
 
         LOG.debug("Creating ISO yum repository")
         createrepo_cmd = "createrepo -v -g %s %s" % (comps_xml_chroot_path,
                                                      mock_iso_repo_dir)
-        self._run_mock_command("--shell '%s'" % createrepo_cmd)
+        self.mock.run_command("--shell '%s'" % createrepo_cmd)
 
     def _create_iso_kickstart(self):
         kickstart_file = self.config.get('automated_install_file')
@@ -152,7 +144,7 @@ class MockPungiIsoBuilder(object):
                 kickstart_file.write("{}\n".format(package))
             kickstart_file.write("%end\n")
 
-        self._run_mock_command("--copyin %s /" % kickstart_path)
+        self.mock.run_command("--copyin %s /" % kickstart_path)
 
     def _build(self):
         LOG.info("Building ISO")
@@ -160,7 +152,7 @@ class MockPungiIsoBuilder(object):
                     (self.pungi_binary, self.pungi_args,
                      self.config.get('automated_install_file'),
                      self.distro, self.version))
-        self._run_mock_command("--shell '%s'" % build_cmd)
+        self.mock.run_command("--shell '%s'" % build_cmd)
 
     def _save(self):
         utils.create_directory(self.result_dir)
@@ -172,8 +164,8 @@ class MockPungiIsoBuilder(object):
         iso_files = "%s/*" % iso_dir
 
         LOG.info("Saving ISO files %s at %s" % (iso_files, self.result_dir))
-        self._run_mock_command("--copyout %s %s" %
-                               (iso_files, self.result_dir))
+        self.mock.run_command("--copyout %s %s" %
+                              (iso_files, self.result_dir))
 
     def clean(self):
-        self._run_mock_command("--clean")
+        self.mock.run_command("--clean")

--- a/lib/mock.py
+++ b/lib/mock.py
@@ -1,0 +1,53 @@
+# Copyright (C) IBM Corp. 2017.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib import config
+from lib import utils
+
+CONF = config.get_config().CONF
+
+class Mock(object):
+    """
+    Centralize calls to mock command, setting the arguments common to
+    all of them.
+    """
+
+    def __init__(self, config_file, unique_extension):
+        """
+        Initialize arguments common to all mock calls.
+
+        Args:
+            config_file (str): configuration file path
+            unique_extension (str): unique extension to append to chroot
+                directory name
+        """
+        self.binary_file = CONF.get('mock_binary')
+        self.config_file = config_file
+        self.extra_args = CONF.get('mock_args') or ""
+        self.unique_extension = unique_extension
+
+        self.common_mock_args = [
+            self.binary_file, "-r", self.config_file, self.extra_args,
+            "--uniqueext", self.unique_extension]
+
+    def run_command(self, cmd):
+        """
+        Run mock command using arguments passed to the constructor.
+
+        Args:
+            cmd (str): mock command to execute
+        """
+        cmd = " ".join(self.common_mock_args + [cmd])
+        utils.run_command(cmd)

--- a/lib/mock_package_builder.py
+++ b/lib/mock_package_builder.py
@@ -26,6 +26,7 @@ from lib import package_builder
 from lib import package_source
 from lib import utils
 from lib.constants import LATEST_SYMLINK_NAME
+from lib.mock import Mock
 
 CONF = config.get_config().CONF
 LOG = logging.getLogger(__name__)
@@ -49,17 +50,11 @@ class MockPackageBuilder(package_builder.PackageBuilder):
             config_file (str): config file path
         """
         super(MockPackageBuilder, self).__init__()
-        binary_file = CONF.get('mock_binary')
-        extra_args = CONF.get('mock_args') or ""
         self.build_dir = None
         self.build_results_dir = CONF.get('result_dir')
         self.archive = None
         self.timestamp = datetime.datetime.now().isoformat()
-        self.common_mock_args = (
-            "%(binary_file)s -r %(config_file)s %(extra_args)s "
-            "--uniqueext %(suffix)s" % dict(
-                binary_file=binary_file, config_file=config_file,
-                extra_args=extra_args, suffix=self.timestamp))
+        self.mock = Mock(config_file, self.timestamp)
 
     def initialize(self):
         """
@@ -67,8 +62,7 @@ class MockPackageBuilder(package_builder.PackageBuilder):
         packages. This setup is common for all packages that are built
         and needs to be done only once.
         """
-        cmd = self.common_mock_args + " --init"
-        utils.run_command(cmd)
+        self.mock.run_command("--init")
 
     def build(self, package):
         """
@@ -94,12 +88,11 @@ class MockPackageBuilder(package_builder.PackageBuilder):
             package (RPM_Package): package
         """
         LOG.info("%s: Building SRPM" % package.name)
-        cmd = (self.common_mock_args
-               + (" --buildsrpm --no-clean --spec %s --sources %s "
-                  "--resultdir=%s %s" % (
-                      package.spec_file.path, self.archive, self.build_dir,
-                      package.get_spec_macros())))
-        utils.run_command(cmd)
+        self.mock.run_command(
+            "--buildsrpm --no-clean --spec %s --sources %s "
+            "--resultdir=%s %s" % (
+                package.spec_file.path, self.archive, self.build_dir,
+                package.get_spec_macros()))
 
     def _build_rpm(self, package):
         """
@@ -108,18 +101,16 @@ class MockPackageBuilder(package_builder.PackageBuilder):
         Args:
             package (RPM_Package): package
         """
-
-        cmd = (self.common_mock_args
-               + " --rebuild %s --no-clean --resultdir=%s %s" % (
-                   self.build_dir + "/*.rpm", self.build_dir,
-                   package.get_spec_macros()))
+        cmd = " --rebuild %s --no-clean --resultdir=%s %s" % (
+            self.build_dir + "/*.rpm", self.build_dir,
+            package.get_spec_macros())
 
         if package.rpmmacro:
             cmd = cmd + " --macro-file=%s" % package.rpmmacro
 
         LOG.info("%s: Building RPM" % package.name)
         try:
-            utils.run_command(cmd)
+            self.mock.run_command(cmd)
 
             # On success save rpms and destroy build directory unless told
             # otherwise.
@@ -187,7 +178,7 @@ class MockPackageBuilder(package_builder.PackageBuilder):
         """
         Clean build environment
         """
-        utils.run_command(self.common_mock_args + " --clean")
+        self.mock.run_command("--clean")
 
     def clean_cache_dir(self, package):
         """
@@ -209,14 +200,12 @@ class MockPackageBuilder(package_builder.PackageBuilder):
             package (RPM_Package): package
         """
         if package.build_dependencies:
-            cmd = self.common_mock_args
-            install = " --install"
+            cmd = "--install"
             for dep in package.build_dependencies:
-                install = " ".join([install, " ".join(dep.cached_build_results)])
+                cmd = " ".join([cmd, " ".join(dep.cached_build_results)])
 
-            cmd = cmd + install
             LOG.info("%s: Installing dependencies on chroot" % package.name)
-            utils.run_command(cmd)
+            self.mock.run_command(cmd)
 
     def _create_build_directory(self, package):
         """

--- a/lib/mock_package_builder.py
+++ b/lib/mock_package_builder.py
@@ -40,7 +40,7 @@ gpgcheck=0
 """
 
 
-class Mock(package_builder.PackageBuilder):
+class MockPackageBuilder(package_builder.PackageBuilder):
     def __init__(self, config_file):
         """
         Constructor
@@ -48,7 +48,7 @@ class Mock(package_builder.PackageBuilder):
         Args:
             config_file (str): config file path
         """
-        super(Mock, self).__init__()
+        super(MockPackageBuilder, self).__init__()
         binary_file = CONF.get('mock_binary')
         extra_args = CONF.get('mock_args') or ""
         self.build_dir = None


### PR DESCRIPTION
This is a step closer to building ISOs concurrently and avoids chroot
conflicts when builds fail.

Refactor code that deals with mock.
Fix distro object creation message being logged multiple times.