### PR TITLE
Handle missing parameters in config file

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -221,7 +221,10 @@ class ConfigParser(object):
         # the subcommand
         for key, value in command_line_args.items():
             if value is None:
-                continue
+                if config.get(key) is None:
+                    raise Exception("Option {} has no value set".format(key))
+                else:
+                    continue
             if key in config:
                 target_type = type(
                     config_metadata["options"][key]["default"])


### PR DESCRIPTION
In case some argument is not provided by command-line, there is an extra step in `config.py` to check whether this argument exists in config file. An exception will be thrown either when the key does not exist, or when it has `None` type assigned to it. 
For optional arguments, the user should provide an empty string.