### PR TITLE
Stop HTTP caches from keeping yum metadata while building ISO

### DIFF
--- a/config/mock/CentOS/7/build-iso-CentOS-7-ppc64le.cfg
+++ b/config/mock/CentOS/7/build-iso-CentOS-7-ppc64le.cfg
@@ -35,6 +35,7 @@ assumeyes=1
 syslog_ident=mock
 syslog_device=
 mdpolicy=group:primary
+http_caching=packages
 
 # repos
 [base]


### PR DESCRIPTION
Pungi uses Yum during the ISO build process. For repos that change
frequently, like EPEL, we are getting old metadata from the cache.