### PR TITLE
Clean mock chroot when ISO build completes

### DIFF
--- a/lib/subcommands/build_iso.py
+++ b/lib/subcommands/build_iso.py
@@ -19,3 +19,4 @@ from lib import iso_builder
 def run(CONF):
     builder = iso_builder.MockPungiIsoBuilder(CONF)
     builder.build()
+    builder.clean()


### PR DESCRIPTION
The MockPungiIsoBuilder.clean() method was never called.