### PR TITLE
Enable networking when building packages

### DIFF
--- a/config/mock/CentOS/7/CentOS-7-ppc64le.cfg
+++ b/config/mock/CentOS/7/CentOS-7-ppc64le.cfg
@@ -1,3 +1,5 @@
+# Enable networking when building packages
+config_opts['rpmbuild_networking'] = True
 # Kill fsync()
 config_opts["nosync"] = True
 # Disable the package state plugin


### PR DESCRIPTION
Since version 1.4.1, mock uses systemd-nspawn by default instead of
chroot, which has a default behavior of disabling networking on execution
of rpmbuild
(https://github.com/rpm-software-management/mock/wiki/Release-Notes-1.4.1).
Since some of the packages may require the download of files during build
(e.g. crash) and to allow building of older versions, we are keeping the
previous behavior by enabling the networking.