### PR TITLE
Use systemd-nspawn for bind mounting

### DIFF
--- a/config/mock/CentOS/7/build-iso-CentOS-7-ppc64le.cfg
+++ b/config/mock/CentOS/7/build-iso-CentOS-7-ppc64le.cfg
@@ -11,11 +11,7 @@ config_opts['plugin_conf']['root_cache_opts']['extension'] = ".lzo"
 config_opts["chroot_setup_cmd"] = "install @buildsys-build /usr/bin/pigz /usr/bin/lbzip2"
 config_opts["macros"]["%__gzip"] = "/usr/bin/pigz"
 config_opts["macros"]["%__bzip2"] = "/usr/bin/lbzip2"
-
-config_opts['plugin_conf']['bind_mount_enable'] = True
-config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/dev','/dev/'))
-config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/dev/pts','/dev/pts/'))
-config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/dev/shm','/dev/shm/'))
+config_opts['nspawn_args'] = ["--bind=/dev", "--bind=/dev/pts", "--bind=/dev/shm"]
 config_opts['root'] = 'CentOS-7-ppc64le'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)


### PR DESCRIPTION
With mock 1.4.2 using systemd-nspawn, these directories are already
mounted.


EDIT: nspawn creates them but it doesn't create any loop devices, so I'm altering the patch to bind mount /dev, but using nspawn this time.