### PR TITLE
Return with an error code when no packages are updated

### DIFF
--- a/lib/exception.py
+++ b/lib/exception.py
@@ -104,3 +104,9 @@ class FilesToValidateNotFound(BaseException):
     # Subclass errors are in the form 0b0110xxx
     error_code = 48
 
+class NoPackagesUpdated(BaseException):
+    DEFAULT_MESSAGE = (
+        "No packages were updated since last commit.")
+    # Subclass errors are in the form 0b0111xxx
+    error_code = 56
+

--- a/lib/subcommands/build_iso.py
+++ b/lib/subcommands/build_iso.py
@@ -13,10 +13,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+
 from lib import iso_builder
+
+LOG = logging.getLogger(__name__)
 
 
 def run(CONF):
     builder = iso_builder.MockPungiIsoBuilder(CONF)
     builder.build()
     builder.clean()
+
+    LOG.info("ISO built succesfully")

--- a/lib/subcommands/build_packages.py
+++ b/lib/subcommands/build_packages.py
@@ -43,3 +43,5 @@ def run(CONF):
     bm.build()
 
     build_info.write_built_pkgs_info_file(bm)
+
+    LOG.info("Packages built succesfully")

--- a/lib/subcommands/build_release_notes.py
+++ b/lib/subcommands/build_release_notes.py
@@ -124,3 +124,5 @@ def run(CONF):
         website_repo.commit_changes(commit_message, updater_name, updater_email)
         if push_updates:
             website_repo.push_head_commits(push_repo_url, push_repo_branch)
+
+    LOG.info("Release notes built succesfully")

--- a/lib/subcommands/update_metapackage.py
+++ b/lib/subcommands/update_metapackage.py
@@ -61,3 +61,5 @@ def run(CONF):
         if push_updates:
             LOG.info("Pushing updated {} files".format(METAPACKAGE_NAME))
             versions_repo.push_head_commits(push_repo_url, push_repo_branch)
+
+    LOG.info("Metapackage updated succesfully")

--- a/lib/subcommands/update_versions.py
+++ b/lib/subcommands/update_versions.py
@@ -260,3 +260,4 @@ def run(CONF):
         if push_updates:
             LOG.info("No updates, pushing branch with unaltered head")
             versions_repo.push_head_commits(push_repo_url, push_repo_branch)
+        raise exception.NoPackagesUpdated()

--- a/lib/subcommands/update_versions.py
+++ b/lib/subcommands/update_versions.py
@@ -261,3 +261,5 @@ def run(CONF):
             LOG.info("No updates, pushing branch with unaltered head")
             versions_repo.push_head_commits(push_repo_url, push_repo_branch)
         raise exception.NoPackagesUpdated()
+
+    LOG.info("Packages updated succesfully")


### PR DESCRIPTION
This allows easy detection when the packages have not changed.

Log a message when the commands finish successfully.


<cde:info> Mirrored with LTC bug #157736 </cde:info>