### PR TITLE
release-notes: create webpage post with information from info files

### DIFF
--- a/config/host_os.yaml
+++ b/config/host_os.yaml
@@ -60,11 +60,7 @@ build-packages:
   update_packages_repos_before_build: true
 build-release-notes:
   commit_updates: true
-  packages_metadata_repo_branch: master
-  packages_metadata_repo_refspecs:
-  - +refs/heads/*:refs/remotes/origin/*
-  - +refs/pull/*:refs/remotes/origin/pr/*
-  packages_metadata_repo_url: https://github.com/open-power-host-os/versions.git
+  info_files_dir: result/packages/latest
   push_repo_branch: master
   push_repo_url: ''
   push_updates: true

--- a/config/metadata.yaml
+++ b/config/metadata.yaml
@@ -39,6 +39,9 @@ options:
   http_proxy:
     help: HTTP proxy URL
     default: ''
+  info_files_dir:
+    help: Path to a directory containing the build information files
+    default: result/packages/latest
   installable_environments:
     help: An environment is a group of package groups. Those
       installable environments will be available at the
@@ -209,17 +212,15 @@ commands:
     help: Build release notes
     options:
     - commit_updates
-    - packages_metadata_repo_branch
-    - packages_metadata_repo_refspecs
-    - packages_metadata_repo_url
+    - info_files_dir
     - push_repo_branch
     - push_repo_url
     - push_updates
     - release_notes_repo_branch
     - release_notes_repo_url
+    - update_packages_repos_before_build
     - updater_email
     - updater_name
-    - update_packages_repos_before_build
   build-iso:
     help: Build ISO image
     options:

--- a/lib/build_info.py
+++ b/lib/build_info.py
@@ -20,13 +20,12 @@ import os
 import pprint
 
 from lib import repository
+from lib.constants import BUILD_INFO_FILE_NAME
+from lib.constants import PACKAGES_INFO_FILE_NAME
 from lib.versions_repository import read_version_and_milestone
 
 CONF = config.get_config().CONF
 LOG = logging.getLogger(__name__)
-
-BUILD_INFO_FILE_NAME = "build.json"
-PACKAGES_INFO_FILE_NAME = "packages.json"
 
 
 class PackageInfo(object):
@@ -95,7 +94,7 @@ def write_build_info(build_manager, versions_repo):
     info_files = {}
     info_files[PACKAGES_INFO_FILE_NAME] = json.dumps(
         query_pkgs_info(build_manager.packages_manager.packages,
-                        ['version', 'rpms', 'sources']),
+                        ['version', 'rpms', 'sources', 'release']),
         sort_keys=True, indent=4)
 
     info_files[BUILD_INFO_FILE_NAME] = json.dumps({

--- a/lib/build_info.py
+++ b/lib/build_info.py
@@ -19,8 +19,14 @@ import logging
 import os
 import pprint
 
+from lib import repository
+from lib.versions_repository import read_version_and_milestone
+
 CONF = config.get_config().CONF
 LOG = logging.getLogger(__name__)
+
+BUILD_INFO_FILE_NAME = "build.json"
+PACKAGES_INFO_FILE_NAME = "packages.json"
 
 
 class PackageInfo(object):
@@ -75,22 +81,35 @@ def query_pkgs_info(packages, target_attrs, include_unbuilt=False):
     return packages_info
 
 
-def write_built_pkgs_info_file(build_manager):
+
+
+def write_build_info(build_manager, versions_repo):
     """
-    Write information about built packages to a file
+    Write build information to a file
 
     Args:
         build_manager(BuildManager): build manager instance
+        versions_repo (GitRepository): versions repository instance
     """
 
-    content = json.dumps(
+    info_files = {}
+    info_files[PACKAGES_INFO_FILE_NAME] = json.dumps(
         query_pkgs_info(build_manager.packages_manager.packages,
                         ['version', 'rpms', 'sources']),
         sort_keys=True, indent=4)
 
-    file_path = os.path.join(
-        CONF.get('result_dir'), 'packages', 'latest', 'packages.json')
-    LOG.info("Writing packages information to file: %s", file_path)
+    info_files[BUILD_INFO_FILE_NAME] = json.dumps({
+        "builds_repo_commit_id": str(repository.GitRepository(".").head.commit.hexsha),
+        "versions_repo_commit_id": str(versions_repo.head.commit.hexsha),
+        "timestamp": build_manager.timestamp,
+        "version": read_version_and_milestone(versions_repo),
+    }, sort_keys=True, indent=4)
 
-    with open(file_path, "w") as info_file:
-        info_file.write(content)
+    for file_name, content in info_files.items():
+        file_path = os.path.join(
+            CONF.get('result_dir'), 'packages', 'latest', file_name)
+
+        LOG.info("Writing information file: %s", file_path)
+
+        with open(file_path, "w") as info_file:
+            info_file.write(content)

--- a/lib/build_manager.py
+++ b/lib/build_manager.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import datetime
 import logging
 import os
 
@@ -33,6 +34,7 @@ class BuildManager(object):
         self.packages_manager = PackagesManager(packages_names)
         self.distro = distro
         self.repositories = None
+        self.timestamp = datetime.datetime.now().isoformat()
 
     def _build_packages(self, distro, packages):
         """
@@ -53,7 +55,7 @@ class BuildManager(object):
             if not os.path.isfile(mock_config_file_path):
                 raise exception.BaseException(
                     "Mock config file not found at %s" % mock_config_file_path)
-            package_builder = MockPackageBuilder(mock_config_file_path)
+            package_builder = MockPackageBuilder(mock_config_file_path, self.timestamp)
         else:
             raise exception.DistributionError()
         # create packages

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -3,3 +3,7 @@ REPOSITORIES_DIR = 'repositories'
 
 # Name of the symlink which points to the latest build results.
 LATEST_SYMLINK_NAME = 'latest'
+
+# Files that contain information about the build
+BUILD_INFO_FILE_NAME = "build.json"
+PACKAGES_INFO_FILE_NAME = "packages.json"

--- a/lib/mock_package_builder.py
+++ b/lib/mock_package_builder.py
@@ -15,7 +15,6 @@
 from functools import partial
 
 
-import datetime
 import logging
 import os
 import shutil
@@ -35,7 +34,7 @@ MOCK_CHROOT_BUILD_DIR = "/builddir/build/SOURCES"
 
 
 class MockPackageBuilder(package_builder.PackageBuilder):
-    def __init__(self, config_file):
+    def __init__(self, config_file, build_timestamp):
         """
         Constructor
 
@@ -46,7 +45,7 @@ class MockPackageBuilder(package_builder.PackageBuilder):
         self.build_dir = None
         self.build_results_dir = CONF.get('result_dir')
         self.archive = None
-        self.timestamp = datetime.datetime.now().isoformat()
+        self.timestamp = build_timestamp
         self.mock = Mock(config_file, self.timestamp)
 
     def initialize(self):

--- a/lib/subcommands/build_packages.py
+++ b/lib/subcommands/build_packages.py
@@ -25,7 +25,7 @@ LOG = logging.getLogger(__name__)
 
 
 def run(CONF):
-    setup_versions_repository(CONF)
+    versions_repo = setup_versions_repository(CONF)
     packages_to_build = (CONF.get('packages') or
                          packages_manager.discover_packages())
     distro = distro_utils.get_distro(
@@ -42,6 +42,6 @@ def run(CONF):
     bm = build_manager.BuildManager(packages_to_build_names, distro)
     bm.build()
 
-    build_info.write_built_pkgs_info_file(bm)
+    build_info.write_build_info(bm, versions_repo)
 
     LOG.info("Packages built succesfully")

--- a/lib/subcommands/build_release_notes.py
+++ b/lib/subcommands/build_release_notes.py
@@ -90,10 +90,12 @@ def run(CONF):
     updater_name = CONF.get('updater_name')
     updater_email = CONF.get('updater_email')
 
-    REQUIRED_PARAMETERS = ["updater_name", "updater_email"]
+    required_parameters = []
+    if commit_updates:
+        required_parameters += ["updater_name", "updater_email"]
     if push_updates:
-        REQUIRED_PARAMETERS += ["push_repo_url", "push_repo_branch" ]
-    for parameter in REQUIRED_PARAMETERS:
+        required_parameters += ["push_repo_url", "push_repo_branch" ]
+    for parameter in required_parameters:
         if not CONF.get(parameter):
             raise exception.RequiredParameterMissing(parameter=parameter)
 


### PR DESCRIPTION
Now that the build script and build pipeline output .json files with data about the build, every front-end component should get data from these files so that we have a single source of data to avoid inconsistencies.

This patch-set alters the creation of the release page posts to make use of the files instead of gathering the information itself.