### PR TITLE
Make the package order deterministic

### DIFF
--- a/lib/packages_manager.py
+++ b/lib/packages_manager.py
@@ -88,4 +88,6 @@ def discover_packages():
     if not package_list:
     	raise exception.PackageDirectoryIsEmpty()
 
+    # Make the package order deterministic
+    package_list.sort()
     return package_list


### PR DESCRIPTION
The os.listdir function returns file names in arbitrary order. Since
our discover_packages function uses it, we were returning the list of
packages also in an arbitrary order. This makes builds and other
subcommands execute non-deterministically for subsequent executions.
In particular, the update-versions and update-metapackage commands were
altering the order of dependencies in the open-power-host-os.yaml file
at random.

By sorting the package names alphabetically, we remove this source of
non-determinism.