### PR TITLE
Remove sos from list of packages to update

### DIFF
--- a/lib/subcommands/update_versions.py
+++ b/lib/subcommands/update_versions.py
@@ -38,7 +38,6 @@ PACKAGES = [
     'ppc64-diag',
     'qemu',
     'servicelog',
-    'sos',
 ]
 
 # prerelease strings supported as last element in the version regex


### PR DESCRIPTION
This package has been removed from versions repository because the
distro's version surpassed ours.