### PR TITLE
Add option to pass a custom commit message

### DIFF
--- a/config/host_os.yaml
+++ b/config/host_os.yaml
@@ -59,6 +59,7 @@ build-packages:
   result_dir: result
   update_packages_repos_before_build: true
 build-release-notes:
+  commit_message: ''
   commit_updates: true
   info_files_dir: result/packages/latest
   push_repo_branch: master
@@ -79,6 +80,7 @@ host_os:
   verbose: false
   work_dir: workspace
 update-metapackage:
+  commit_message: ''
   commit_updates: true
   packages_metadata_repo_branch: master
   packages_metadata_repo_refspecs:
@@ -92,6 +94,7 @@ update-metapackage:
   updater_email: ''
   updater_name: ''
 update-versions:
+  commit_message: ''
   commit_updates: true
   packages: []
   packages_metadata_repo_branch: master

--- a/config/metadata.yaml
+++ b/config/metadata.yaml
@@ -6,6 +6,10 @@ options:
     help: Path of a kickstart file, used to automate the installation of an
       RPM-based Linux distribution
     default: host-os.ks
+  commit_message:
+    help: Message used when creating the commit. If empty, a command-dependent
+      generic message is used.
+    default: ''
   commit_updates:
     help: Commit file updates to local repository
     default: True
@@ -215,6 +219,7 @@ commands:
   build-release-notes:
     help: Build release notes
     options:
+    - commit_message
     - commit_updates
     - info_files_dir
     - push_repo_branch
@@ -246,6 +251,7 @@ commands:
   update-metapackage:
     help: Update the metapackage dependencies
     options:
+    - commit_message
     - commit_updates
     - packages_metadata_repo_branch
     - packages_metadata_repo_refspecs
@@ -259,6 +265,7 @@ commands:
   update-versions:
     help: Update packages versions
     options:
+    - commit_message
     - commit_updates
     - packages
     - packages_metadata_repo_branch

--- a/lib/subcommands/build_release_notes.py
+++ b/lib/subcommands/build_release_notes.py
@@ -126,7 +126,9 @@ def run(CONF):
                        build_info, packages_info)
 
     if commit_updates:
-        commit_message = "Host OS release of {date}".format(date=release_date)
+        commit_message = (
+            CONF.get('commit_message')
+            or "Host OS release of {date}".format(date=release_date))
         website_repo.commit_changes(commit_message, updater_name, updater_email)
         if push_updates:
             website_repo.push_head_commits(push_repo_url, push_repo_branch)

--- a/lib/subcommands/update_metapackage.py
+++ b/lib/subcommands/update_metapackage.py
@@ -55,7 +55,8 @@ def run(CONF):
         updater_name, updater_email)
 
     if commit_updates:
-        commit_message = "Update {} dependencies".format(METAPACKAGE_NAME)
+        commit_message = (CONF.get('commit_message')
+                          or "Update {} dependencies".format(METAPACKAGE_NAME))
         versions_repo.commit_changes(
             commit_message, updater_name, updater_email)
         if push_updates:

--- a/lib/subcommands/update_versions.py
+++ b/lib/subcommands/update_versions.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
 import logging
 import os
 import re
@@ -239,8 +238,8 @@ def run(CONF):
             updater_name, updater_email)
 
         if commit_updates:
-            release_date = datetime.today().date().isoformat()
-            commit_message = "Weekly build {date}".format(date=release_date)
+            commit_message = (CONF.get('commit_message')
+                              or "Update packages versions")
             versions_repo.commit_changes(
                 commit_message, updater_name, updater_email)
 


### PR DESCRIPTION
This allows automated pipelines to customize the messages in the commits
they create. A default generic message is still provided for easy manual
execution.