### PR TITLE
Enable chroot networking when building ISO

### DIFF
--- a/config/mock/CentOS/7/CentOS-7-ppc64le.cfg
+++ b/config/mock/CentOS/7/CentOS-7-ppc64le.cfg
@@ -1,4 +1,4 @@
-# Enable networking when building packages
+# Enable networking
 config_opts['rpmbuild_networking'] = True
 # Kill fsync()
 config_opts["nosync"] = True

--- a/config/mock/CentOS/7/build-iso-CentOS-7-ppc64le.cfg
+++ b/config/mock/CentOS/7/build-iso-CentOS-7-ppc64le.cfg
@@ -1,3 +1,5 @@
+# Enable networking
+config_opts['rpmbuild_networking'] = True
 # Kill fsync()
 config_opts["nosync"] = True
 # Disable the package state plugin


### PR DESCRIPTION
Previously, mock only disabled networking when building RPMs, if the
'rpmbuild_networking' option was not set. Since version 1.4.6
(https://github.com/rpm-software-management/mock/wiki/Release-Notes-1.4.6),
it disables networking by default for shell commands too, so we have to
enable it during ISO builds to restore the previous behaviour and allow
yumdownloader to download the packages.