### PR TITLE
Fix VERSION path in metapackage.py

### DIFF
--- a/lib/metapackage.py
+++ b/lib/metapackage.py
@@ -109,7 +109,9 @@ def update_metapackage(
         YAML_START_DELIMITER)
 
     LOG.info("Updating release package spec file")
-    version_file_path = os.path.join(versions_repo.working_tree_dir, "VERSION")
+    version_file_path = os.path.join(versions_repo.working_tree_dir,
+                                     "open-power-host-os", "CentOS", "7",
+                                     "SOURCES", "VERSION")
     with open(version_file_path) as version_file:
         version_parts = version_file.readlines()[-1].strip().split("-")
     new_metapackage_version = version_parts.pop(0)


### PR DESCRIPTION
This updates the VERSION file path in metapackage.py, otherwise an
error is shown during `update-versions` sub-command:

```
Traceback (most recent call last):
  File "host_os.py", line 79, in <module>
    SUBCOMMANDS[subcommand].run(CONF)
  File "/home/jenkins-slave/workspace/devel/builds/lib/subcommands/update_versions.py", line 238, in run
    updater_name, updater_email)
  File "/home/jenkins-slave/workspace/devel/builds/lib/metapackage.py", line 113, in update_metapackage
    with open(version_file_path) as version_file:
IOError: [Errno 2] No such file or directory: '/var/tmp/host-os/repositories/versions_update-versions/VERSION'
```