### PR TITLE
lib/repository.py: Call git command to update submodules

### DIFF
--- a/lib/repository.py
+++ b/lib/repository.py
@@ -191,10 +191,8 @@ class GitRepository(git.Repo):
         """
         Update repository submodules, initializing them if needed.
         """
-        for submodule in self.submodules:
-            LOG.info("Updating submodule %(name)s from %(url)s"
-                     % dict(name=submodule.name, url=submodule.url))
-            submodule.update(init=True)
+        LOG.info("Updating submodules of repo %(repo)s" % dict(repo=self.name))
+        self.git.submodule('update', '--init', '--recursive')
 
     def archive(self, archive_name, build_dir):
         """


### PR DESCRIPTION
GitPython assumes that a default reference, branch_path=refs/heads/master, will
exist on the submodule repository. However, this is not true for all cases. For
example, seabios-hppa submodule of qemu only has parisc_firmware branch and
GitPython fails to update seabios-hppa submodule:

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/lib/python2.7/site-packages/git/objects/submodule/base.py", line 520, in update
        remote_branch = find_first_remote_branch(mrepo.remotes, self.branch_name)
      File "/usr/lib/python2.7/site-packages/git/objects/submodule/util.py", line 38, in find_first_remote_branch
        raise InvalidGitRepositoryError("Didn't find remote branch '%r' in any of the given remotes" % branch_name)
    git.exc.InvalidGitRepositoryError: Didn't find remote branch ''master'' in any of the given remotes

This fixes the issue by calling git command directly from the git.Repo object,
which uses the HEAD reference from the cloned submodule repository. Thus, we
don't need to worry about if refs/heads/master exists on the submodule
repository and GitPython succeeds to update repository submodules.

Thanks to Fabiano Almeida Rosas that helped on this troubleshooting.