### PR TITLE
iso_builder: Add packages required by lorax

### DIFF
--- a/lib/iso_builder.py
+++ b/lib/iso_builder.py
@@ -66,6 +66,9 @@ ISO_REPO_MINIMAL_PACKAGES = [
     "jomolhari-fonts",
     "khmeros-base-fonts",
     "sil-padauk-fonts",
+    # Packages required by lorax
+    "dracut-fips", # https://github.com/weldr/lorax/pull/230 (commit: 7aa7118)
+    "kernel-bootwrapper",
 ]
 CHROOT_HOST_OS_REPO_PATH = "/host-os-repo"
 CHROOT_MERGED_REPO_PATH = "/merged-repo"


### PR DESCRIPTION
We have a custom minimal yum repository inside the chroot during the
ISO build so packages need to be added manually to it as needed.

kernel-bootwrapper is not being pulled in anymore so that needs to be
added back. It is used by lorax:

https://github.com/weldr/lorax/commit/1350cd028f48530fc3836addebc7d6bd01fbd93b#diff-8c895912e6e654d0a83ad2c114021a3eR9

CentOS update brought a new lorax (19.6.104) which requires
'dracut-fips' for initramfs creation:

https://github.com/weldr/lorax/pull/230/commits/7aa71188b9dc48ed3486cc1134d32d786a942e78