### PR TITLE
lib/utils: check for installed packages in a more reliable way

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -166,7 +166,7 @@ def is_package_installed(package_name):
         bool: if RPM package is installed
     """
 
-    cmd = "rpm -q %s" % package_name
+    cmd = "rpm -q --whatprovides %s" % package_name
     try:
         run_command(cmd, shell=True)
     except exception.SubprocessError as e:


### PR DESCRIPTION
Some rpm packages might be installed under a different name than what
we expect. For instance:

$ rpm -qa | grep GitPython
python2-GitPython-2.1.7-2.fc26.noarch

$ rpm -q GitPython
package GitPython is not installed

This patch uses a more flexible approach to checking for installed
packages:

$ rpm -q --whatprovides GitPython
python2-GitPython-2.1.7-2.fc26.noarch