### PR TITLE
Fix command line parsing of dicts

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import json
 import os
 import sys
 
@@ -86,10 +87,19 @@ class ConfigParser(object):
         long_option_string = "--" + option_name.replace("_", "-")
         if keyword_args.get("action", "store") == "store":
             option_type = type(option_dict["default"])
+
             if option_type == list:
                 keyword_args["nargs"] = "*"
+                if option_dict["default"]:
+                    option_type = type(option_dict["default"][0])
+                else:
+                    option_type = None
+
+            if option_type == dict:
+                keyword_args["type"] = json.loads
             else:
                 keyword_args["type"] = option_type
+
         elif keyword_args.get("action", "store") == "store_false":
             long_option_string = "--no-" + option_name.replace("_", "-")
         option_strings = [long_option_string]

--- a/tests/unit/config_tests.py
+++ b/tests/unit/config_tests.py
@@ -19,12 +19,18 @@ class TestConfigParser(unittest.TestCase):
         (['build-packages', '--packages-metadata-repo-url=foo'], 'packages_metadata_repo_url', 'foo'),
         (['build-packages', '--packages-metadata-repo-branch=foo'], 'packages_metadata_repo_branch', 'foo'),
         (['build-packages', '--mock-args=foo'], 'mock_args', 'foo'),
+        (['build-packages', '--rpm-macros', '{"macro1":"value1", "macro2":"value2"}'], 'rpm_macros',
+         {"macro1":"value1","macro2":"value2"}),
         (['build-release-notes', '--push-repo-url=foo'], 'push_repo_url', 'foo'),
         (['build-release-notes', '--push-repo-branch=foo'], 'push_repo_branch', 'foo'),
         (['build-release-notes', '--updater-name=foo'], 'updater_name', 'foo'),
         (['build-release-notes', '--updater-email=foo'], 'updater_email', 'foo'),
         (['build-images', '--packages-dir=foo'], 'packages_dir', 'foo'),
         (['build-images', '--mock-args=foo'], 'mock_args', 'foo'),
+        (['build-images', '--distro-repos', '{"a":1,"b":2}', '{"a":{"b":2}}'], 'distro_repos',
+         [{"a":1,"b":2}, {"a":{"b":2}}]),
+        (['build-images', '--installable-environments', '{"env1": ["group1", "group2"]}'], 'installable_environments',
+         {"env1":["group1","group2"]}),
         (['update-versions', '--no-commit-updates'], 'commit_updates', False),
         (['update-versions', '--no-push-updates'], 'push_updates', False),
     ])
@@ -50,6 +56,7 @@ class TestConfigParser(unittest.TestCase):
          '--plugin-option=tmpfs:keep_mounted=True --plugin-option='
          'tmpfs:max_fs_size=32g --plugin-option=tmpfs:required_ram_mb=39800 '
          '--verbose'),
+        (['build-packages'], 'rpm_macros', {}),
         (['build-release-notes'], 'push_repo_url', ''),
         (['build-release-notes'], 'push_repo_branch', 'master'),
         (['build-release-notes'], 'updater_name', ''),


### PR DESCRIPTION
Python dicts were being parsed as strings before. This patch makes it
so they are parsed as json objects. This allows for the following
syntax in command line:

host_os.py --opt '{"a":1, "b":"c", "d": {"e":3}}'

This also works for lists of dicts:

host_os.py --opt '{"a":1}' '{"b":"c", "d": {"e":3}}'