### PR TITLE
Remove lsvpd and ppc64-diag

### DIFF
--- a/lib/subcommands/update_versions.py
+++ b/lib/subcommands/update_versions.py
@@ -33,8 +33,6 @@ PACKAGES = [
     'libservicelog',
     'libvirt',
     'libvpd',
-    'lsvpd',
-    'ppc64-diag',
     'qemu',
     'servicelog',
 ]


### PR DESCRIPTION
These were removed in the versions repo by

https://github.com/open-power-host-os/versions/pull/269